### PR TITLE
Allow multiple API keys management with profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .ovhApplication*
 .ovhConsumerKey*
 libs/
-
+profile/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ovh API Bash client
+ orovh API Bash client
 ================
 
 A bash client for OVH API (https://api.ovh.com/)
@@ -69,10 +69,8 @@ To activate the monitoring on your dedicated server, run:
     ./ovh-api-bash-client.sh --method PUT --url "/dedicated/server/ns00000.ovh.net" --data '{"monitoring": true}'
 ```
 
-create a Consumer key for different account or usage
+To create a Consumer key for different account or usage (profile is created if missing)
 ```
-    mkdir profile/demo1
-    mkdir profile/demo2
     ./ovh-api-bash-client.sh --profile demo1 --init
     ./ovh-api-bash-client.sh --profile demo2 --init
 ```

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Options
 
 Possible arguments are:
 ```
-    --url <url>         : the API URL to call, for example /domains (default is /me)
-    --method <method>   : the HTTP method to use, for example POST (default is GET)
-    --data <JSON data>  : the data body to send with the request
-    --target <CA|EU>    : the target API (default is EU)
-    --init              : to initialize the consumer key
-    --initApp           : to initialize the API application
-    --profile <dir>     : load a configuration from profile/ directory, (override default location)
-    --list-profile      : list available profiles in profile/ directory    
+  --url <url>             : the API URL to call, for example /domains (default is /me)
+  --method <method>       : the HTTP method to use, for example POST (default is GET)
+  --data <JSON data>      : the data body to send with the request
+  --target <CA|EU>        : the target API (default is EU)
+  --init                  : to initialize the consumer key
+  --initApp               : to initialize the API application
+  --list-profile          : list available profiles in profile/ directory
+  --profile <value>
+            * default : from script directory
+            * <dir>   : from profile/<dir> directory
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ In order to create a new consumer key, run:
 Options
 -------
 
+### Show help
+```
+    ./ovh-api-bash-client.sh --help
+```
+
 Possible arguments are:
 ```
     --url <url>         : the API URL to call, for example /domains (default is /me)
@@ -38,6 +43,8 @@ Possible arguments are:
     --target <CA|EU>    : the target API (default is EU)
     --init              : to initialize the consumer key
     --initApp           : to initialize the API application
+    --profile <dir>     : load a configuration from profile/ directory, (override default location)
+    --list-profile      : list available profiles in profile/ directory    
 ```
 
 Usage
@@ -60,3 +67,10 @@ To activate the monitoring on your dedicated server, run:
     ./ovh-api-bash-client.sh --method PUT --url "/dedicated/server/ns00000.ovh.net" --data '{"monitoring": true}'
 ```
 
+create a Consumer key for different account or usage
+```
+    mkdir profile/demo1
+    mkdir profile/demo2
+    ./ovh-api-bash-client.sh --profile demo1 --init
+    ./ovh-api-bash-client.sh --profile demo2 --init
+```


### PR DESCRIPTION
Hi @denouche , Thanks for your script, very useful !

Here, I've resolved some limitations :

-  Your script can use only one pair of Application+Consumer Keys, but we may need to use it for many OVH accounts or uses.
-  When you init keys, it force all grants to the API : It may be dangerous if using your client on a server with automated tasks.

Regards