### PR TITLE
move profiles to user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Possible arguments are:
   --method <method>       : the HTTP method to use, for example POST (default is GET)
   --data <JSON data>      : the data body to send with the request
   --target <CA|EU>        : the target API (default is EU)
-  --init                  : to initialize the consumer key
+  --init                  : to initialize the consumer key, and manage custom access rules file
   --initApp               : to initialize the API application
-  --list-profile          : list available profiles in profile/ directory
+  --list-profile          : list available profiles in ~/.ovh-api-bash-client/profile directory
   --profile <value>
-            * default : from script directory
-            * <dir>   : from profile/<dir> directory
+            * default : from ~/.ovh-api-bash-client/profile directory
+            * <dir>   : from ~/.ovh-api-bash-client/profile/<dir> directory
 ```
 
 Usage

--- a/ovh-api-bash-client.sh
+++ b/ovh-api-bash-client.sh
@@ -311,18 +311,26 @@ initProfile()
   if [ -d "${LEGACY_PROFILES_PATH}" ]; then
     # is there any profile in legacy path ?
     legacy_profiles=$(ls -A "${LEGACY_PROFILES_PATH}" 2>/dev/null)
-    legacy_default_profile=$(ls -A "${BASE_PATH}"/.ovh* 2>/dev/null)
+    legacy_default_profile=$(cd "${BASE_PATH}" && ls .ovh* access.rules 2>/dev/null)
+
     if [ -n "${legacy_profiles}" ] || [ -n "${legacy_default_profile}" ]; then
-      _echoWarning "Your profiles resides in the legacy path:"
-      echo "${legacy_profiles}"
-      echo "${legacy_default_profile}"
-      _echoWarning "Please move them to this new location like this:"
-      [ -n "${legacy_profiles}" ] && _echoWarning "  mv ${LEGACY_PROFILES_PATH}/* ${PROFILES_PATH}"
-      [ -n "${legacy_default_profile}" ] && _echoWarning "  mv ${BASE_PATH}/.ovh* access.rules ${PROFILES_PATH}"
-      exit 1
+      # notify about migration to new location:
+      _echoWarning "Your profiles were in the legacy path, migrating to ${PROFILES_PATH} :"
+
+      if [ -n "${legacy_default_profile}" ]; then
+          _echoWarning "> migrating default profile:"
+          echo "${legacy_default_profile}"
+          mv ${BASE_PATH}/.ovh* access.rules "${PROFILES_PATH}"
+      fi
+
+      if [ -n "${legacy_profiles}" ]; then
+          _echoWarning "> migrating custom profiles:"
+          echo "${legacy_profiles}"
+          mv ${LEGACY_PROFILES_PATH}/* "${PROFILES_PATH}"
+      fi
+
     fi
   fi
-
 
   # if profile is not set, or with value 'default'
   if [[ -z "${profile}" ]] || [[ "${profile}" == "default" ]]

--- a/ovh-api-bash-client.sh
+++ b/ovh-api-bash-client.sh
@@ -32,7 +32,8 @@ do
 done
 BASE_PATH=$( cd -P "$( dirname "${SOURCE}" )" && pwd )
 
-PROFILES_PATH="${BASE_PATH}/profile"
+LEGACY_PROFILES_PATH="${BASE_PATH}/profile"
+PROFILES_PATH="${HOME}/.ovh-api-bash-client/profile"
 
 HELP_CMD="$0"
 
@@ -44,6 +45,11 @@ TIME=""
 SIGDATA=""
 POST_DATA=""
 PROFILE=""
+
+_echoWarning()
+{
+  echo >&2 "[WARNING] $*"
+}
 
 isTargetValid()
 {
@@ -161,10 +167,10 @@ help()
     echo "  --target <$( echo ${TARGETS[@]} | sed 's/\s/|/g' )>        : the target API (default is EU)"
     echo "  --init                  : to initialize the consumer key, and manage custom access rules file"
     echo "  --initApp               : to initialize the API application"
-    echo "  --list-profile          : list available profiles in profile/ directory"
+    echo "  --list-profile          : list available profiles in ~/.ovh-api-bash-client/profile directory"
     echo "  --profile <value>"
-    echo "            * default : from script directory"
-    echo "            * <dir>   : from profile/<dir> directory"
+    echo "            * default : from ~/.ovh-api-bash-client/profile directory"
+    echo "            * <dir>   : from ~/.ovh-api-bash-client/profile/<dir> directory"
     echo
 }
 
@@ -200,7 +206,7 @@ buildAccessRules()
   done < "${access_rules_file}"
   json_rules=${json_rules::-1}
   if [ -z "${json_rules}" ]; then
-    echo "no rule defined, please verify your file '${access_rules_file}'" >&2
+    echoWarning "no rule defined, please verify your file '${access_rules_file}'"
     exit 1
   fi
 
@@ -296,14 +302,33 @@ initProfile()
 
   if [ ! -d "${PROFILES_PATH}" ]
   then
-    mkdir "${PROFILES_PATH}" || exit 1
+    mkdir -pv "${PROFILES_PATH}" || exit 1
   fi
+
+  # checking if some profiles remains in legacy profile path
+  local legacy_profiles=
+  local legacy_default_profile=
+  if [ -d "${LEGACY_PROFILES_PATH}" ]; then
+    # is there any profile in legacy path ?
+    legacy_profiles=$(ls -A "${LEGACY_PROFILES_PATH}" 2>/dev/null)
+    legacy_default_profile=$(ls -A "${BASE_PATH}"/.ovh* 2>/dev/null)
+    if [ -n "${legacy_profiles}" ] || [ -n "${legacy_default_profile}" ]; then
+      _echoWarning "Your profiles resides in the legacy path:"
+      echo "${legacy_profiles}"
+      echo "${legacy_default_profile}"
+      _echoWarning "Please move them to this new location like this:"
+      [ -n "${legacy_profiles}" ] && _echoWarning "  mv ${LEGACY_PROFILES_PATH}/* ${PROFILES_PATH}"
+      [ -n "${legacy_default_profile}" ] && _echoWarning "  mv ${BASE_PATH}/.ovh* access.rules ${PROFILES_PATH}"
+      exit 1
+    fi
+  fi
+
 
   # if profile is not set, or with value 'default'
   if [[ -z "${profile}" ]] || [[ "${profile}" == "default" ]]
   then
-    # configuration stored in the script path
-    CURRENT_PATH="${BASE_PATH}"
+    # configuration stored in the profile main path
+    CURRENT_PATH="${PROFILES_PATH}"
   else
     # ensure profile directory exists
     if [ ! -d "${PROFILES_PATH}/${profile}" ]

--- a/ovh-api-bash-client.sh
+++ b/ovh-api-bash-client.sh
@@ -320,7 +320,7 @@ initProfile()
       if [ -n "${legacy_default_profile}" ]; then
           _echoWarning "> migrating default profile:"
           echo "${legacy_default_profile}"
-          mv ${BASE_PATH}/.ovh* access.rules "${PROFILES_PATH}"
+          mv ${BASE_PATH}/{.ovh*,access.rules} "${PROFILES_PATH}"
       fi
 
       if [ -n "${legacy_profiles}" ]; then


### PR DESCRIPTION
Hi @denouche , yet another idea : 

In my mind the [script_dir]/profile/ and [script_dir]/.ovh* should be there: 

- The script dir is strange hidden place for default profile
- the script cannot manage profiles as-is  if installed globally on system paths (in /usr/local/ovh-api-bash-client for example)

So I've decided to put profiles under user home directory `~/.ovh-api-bash-client/profile` 
(sub-dir for non-default profile)

this new profile location is useful for: 
- single installation on the OS, and use it with any user.
- also ovh-api-bash-client.sh packaging purpose (teasing: I'm preparing this :-) )

I've added a check: 
if the script find profiles present in the old locations, it warn the user about the commands to execute to move to the new location, and die. 
It's a oneshot action, so this part may be added to an external script for profile migration

It's a work in progress idea,
waiting for your advice.

Regards
