### PR TITLE
ovhapilib bugfix: JSON datas must be set when PUT method is used

### DIFF
--- a/contrib/ovh-api-lib.sh
+++ b/contrib/ovh-api-lib.sh
@@ -65,7 +65,7 @@ OvhRequestApi()
     cmd+=(--target "${OVHAPI_TARGET}")
   fi
 
-  if [ "${method}" == "POST" ]; then
+  if [ "${method}" == "POST" ] || [ "${method}" == "PUT" ]; then
       # double-quote data content for bash input
       data=$(printf "%q" "${data}")
       cmd+=(--data "${data}")


### PR DESCRIPTION
Hi @denouche, from now we can play with PUT method when using OvhRequestApi function
