### PR TITLE
OvhRequestApi: Ensure to escape querystring arguments

### DIFF
--- a/contrib/jsonsh-lib.sh
+++ b/contrib/jsonsh-lib.sh
@@ -114,7 +114,7 @@ _JSonSH_rewrite_output()
 
        ## Actions on json key :
        # 1) remove some chars : brackets and double quotes
-       gsub(/\[|\]|\"/,"",json_key)
+       gsub(/\[|\]|"/,"",json_key)
        # 2) detect array index between comma, put digits between brackets
        json_key = gensub(/(,([[:digit:]]+)(,|))/,"[\\2]\\3","g",json_key)
        # 3) replace each comma with dot

--- a/contrib/ovh-api-lib.sh
+++ b/contrib/ovh-api-lib.sh
@@ -54,6 +54,8 @@ OvhRequestApi()
   cmd_profile=${cmd[*]}
 
   if [ -n "${url}" ]; then
+    # escape querystring arguments
+    url=$(printf "%q" "${url}")
     cmd+=(--url "${url}")
   fi
 


### PR DESCRIPTION
Hi @denouche 

I'm always using ovh-api-bash-client, and I've freshly discovered a major bug in `OvhRequestApi()`
When calling an URL with at least two arguments, only the first was forwarded to the main script, and so to OVH API

So,  something like `/action?foo=bar&baz=123` was forwarded as  `/action?foo=bar`

The function `updateSignData()` allowed me to understand what's happened to the querystring 

Here is a little fix for a useful improvement.


Regards !

